### PR TITLE
Move searchable to scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,8 @@ group :development, :test do
 end
 
 group :test do
-  gem 'rspec_html_formatter','~> 0.3.1'
+  gem 'rspec-core'
+  gem 'rspec_html_formatter', '~> 0.3.1'
 end
 
 group :development do
@@ -58,6 +59,7 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'aws-sdk', '~> 2.3.0'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'cancancan', '~> 2.0'
 gem 'devise'
@@ -73,4 +75,4 @@ gem 'rubocop'
 gem 'rubycritic'
 gem 'seed_dump'
 gem 'tzinfo-data', :platforms => %i[mingw mswin x64_mingw jruby]
-gem 'aws-sdk', '~> 2.3.0'
+

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -8,23 +8,13 @@ class ListingsController < ApplicationController
   # GET /listings.json
   def index
     ###
+    @listings = Listing.where(nil)
     logger.debug "In listing controller index - at top - params: #{params}"
-    if params[:search]
-      @listings = []
-      (Listing.search params[:search]).each do |listing|
-        @listings += Listing.where(:id => [listing._id]).to_a
-      end
-      logger.debug "In listing controller index - at after if params search - @listings: #{@listings}"
-    else
-
-      redirect_params(params).each do |key, value|
-        {
-          @listings = @listings.public_send(key, value) => value
-        }
-      end
-
-      respond_with(@listings)
-    end ###
+    redirect_params(params).each do |key, value|
+      @listings = @listings.public_send(key, value) if value.present?
+    end
+    logger.debug "In Listing controller index, returning listings:  #{@listings.inspect}"
+    respond_with(@listings)
   end
 
   # GET /listings/1
@@ -42,10 +32,6 @@ class ListingsController < ApplicationController
   # POST /listings
   # POST /listings.json
   def create
-    puts 'listing params:'
-    puts listing_params.inspect
-    puts 'params:'
-    puts params.inspect
     @listing = Listing.new(listing_params)
     if @listing.save
       create_images if params[:images]
@@ -105,7 +91,8 @@ class ListingsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def listing_params
-    params.require(:listing).permit(:title, :search, :tag, :category_id, :user_id, :pictures, :all_tags, :location, :description, :price)
+    params.require(:listing).permit(:title, :search, :tag, :category_id, :user_id, :pictures, :all_tags,
+                                    :location, :description, :price)
   end
 
   def redirect_params(params)

--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -11,17 +11,37 @@ module ListingsHelper
     "Hi,\n\nI am interested in your listing titled #{listing.title} on UNO Classifieds.\n\n"
   end
 
+  def self.category_id(listing, context, param)
+    cat_name = listing.category.name.titleize
+    %(in the #{context.make_link(cat_name, param)} category ).html_safe
+  end
+
+  def self.tag(_, context, param)
+    %(with tags like #{context.make_link(param.values.first, param)} ).html_safe
+  end
+
+  def self.user_id(listing, context, param)
+    name = listing.user.name
+    %(posted by #{context.make_link(name, param)} ).html_safe
+  end
+
+  def self.search(_, _, param)
+    "with description like #{param[:search]} "
+  end
+
+  def make_link(string = nil, param = {})
+    %( #{link_to(string, listings_path(param))} ).html_safe
+  end
+
   def index_welcome(params)
-    welcome = 'Listings %s %s %s'
-    if params[:category_id]
-      format(welcome, 'in the ', Category.find(params[:category_id]).name.titleize, ' category')
-    elsif params[:tag]
-      format(welcome, 'tagged with the ', params[:tag], ' tag')
-    elsif params[:user_id]
-      format(welcome, 'posted by ', User.find(params[:user_id]).name, '')
-    else
-      'All Listings'
+    filter_params = controller.send(:redirect_params, params)
+    return 'No Listings found' if @listings.empty?
+    return make_link('Listings').to_s if filter_params.empty?
+    welcome = %(#{make_link('Listings')} ).html_safe
+    filter_params.each do |key, value|
+      welcome += ListingsHelper.public_send(key, @listings.first, self, key => value) if value.present?
     end
+    welcome
   end
 end
 

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -31,15 +31,6 @@ class Listing < ApplicationRecord
   def all_tags
     tags.map(&:name).join(', ')
   end
-
-  # def self.tag(name)
-  #   listings = Set.new
-  #   logger.debug "In listing model: About to do a fuzzy match - on tag: #{name}"
-  #   Tag.find_by_fuzzy_name(name).each do |tag|
-  #     listings.merge(tag.listings)
-  #   end
-  #   listings.to_a
-  # end
 end
 
 # Delete the previous listings index in Elasticsearch

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -14,6 +14,11 @@ class Listing < ApplicationRecord
   scope :category_id, ->(category_id) { where(:category_id => category_id) }
   scope :user_id, ->(user_id) { where(:user_id => user_id) }
   scope :has_picture, -> { includes(:pictures).where.not(:pictures => { :id => nil }) }
+  scope :search, ->(q) { where(:id => Listing.__elasticsearch__.search(q).map(&:_id)) }
+  scope :tag, lambda { |tag|
+    logger.debug "In listing model: About to do a fuzzy match - on tag: #{name}"
+    where(:id => Tagging.where(:tag_id => Tag.find_by_fuzzy_name(tag).map(&:id)).map(&:listing_id))
+  }
 
   validates :title, :presence => true
 
@@ -27,20 +32,20 @@ class Listing < ApplicationRecord
     tags.map(&:name).join(', ')
   end
 
-  def self.tag(name)
-    listings = Set.new
-    logger.debug "In listing model: About to do a fuzzy match - on tag: #{name}"
-    Tag.find_by_fuzzy_name(name).each do |tag|
-      listings.merge(tag.listings)
-    end
-    listings
-  end
+  # def self.tag(name)
+  #   listings = Set.new
+  #   logger.debug "In listing model: About to do a fuzzy match - on tag: #{name}"
+  #   Tag.find_by_fuzzy_name(name).each do |tag|
+  #     listings.merge(tag.listings)
+  #   end
+  #   listings.to_a
+  # end
 end
 
 # Delete the previous listings index in Elasticsearch
 begin
   Listing.__elasticsearch__.client.indices.delete :index => Listing.index_name
-rescue
+rescue StandardError
   nil
 end
 

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Listing, :type => :model do
   end
 
   describe '.tag' do
-    it 'returns a set of listings' do
-      expect(Listing.tag('')).to be_a(Set)
+    it 'returns a scope(ActiveRecord_Relation' do
+      expect(Listing.tag('')).to be_a(Listing::ActiveRecord_Relation)
     end
 
     context 'when retrieving apple tag' do

--- a/spec/views/listings/edit.html.erb_spec.rb
+++ b/spec/views/listings/edit.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'listings/edit', :type => :view do
   before(:each) do
-    view.stub(:current_user) { FactoryBot.create(:admin) }
+    allow(view).to receive(:current_user).and_return(FactoryBot.create(:admin))
     @listing = FactoryBot.create(:listing)
   end
 

--- a/spec/views/listings/index.html.erb_spec.rb
+++ b/spec/views/listings/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'listings/index', :type => :view do
   end
 
   module StubControllerMethod
-    def redirect_params(params)
+    def redirect_params(_params)
       {}
     end
   end

--- a/spec/views/listings/index.html.erb_spec.rb
+++ b/spec/views/listings/index.html.erb_spec.rb
@@ -2,12 +2,20 @@ require 'rails_helper'
 
 RSpec.describe 'listings/index', :type => :view do
   before(:each) do
-    view.stub(:current_user) { FactoryBot.create(:admin) }
+    allow(view).to receive(:current_user).and_return(FactoryBot.create(:admin))
     FactoryBot.create(:category)
     @listings = build_list(:listing, 2)
   end
 
+  module StubControllerMethod
+    def redirect_params(params)
+      {}
+    end
+  end
+
+
   it 'renders a list of listings' do
+    controller.extend(StubControllerMethod)
     render
     expect(rendered).to match(/title/)
     # assert_select 'tr>td', :text => 'Title'.to_s, :count => 2

--- a/spec/views/listings/new.html.erb_spec.rb
+++ b/spec/views/listings/new.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'listings/new', :type => :view do
   before(:each) do
-    view.stub(:current_user) { FactoryBot.create(:admin) }
+    allow(view).to receive(:current_user).and_return(FactoryBot.create(:admin))
     cat = FactoryBot.create(:category)
     assign(:listing, Listing.new(
                        :title => 'MyString',


### PR DESCRIPTION
 Allows chaining of any searchables (user, category, tag, search bar), simplifies index controller.  Updates index_welcome to print message and link for each searchable.  
